### PR TITLE
Change default plan selection to monthly

### DIFF
--- a/src/components/AdPreview.tsx
+++ b/src/components/AdPreview.tsx
@@ -138,7 +138,7 @@ export const AdPreview: React.FC<AdPreviewProps> = ({
                       />
                     </div>
                     <div>
-                      <div className="font-semibold text-sm text-card-foreground">Lofty Real Estate</div>
+                      <div className="font-semibold text-sm text-card-foreground"><p>Real Estate Service</p></div>
                       <div className="text-xs text-muted-foreground">Sponsored</div>
                     </div>
                   </div>
@@ -353,7 +353,7 @@ export const AdPreview: React.FC<AdPreviewProps> = ({
                         }`}
                       />
                       <p className="text-xs text-muted-foreground">
-                        Recommended: 1200x630px
+                        <p>Recommended Aspect Ratio: 1:1 or 4:5</p>
                       </p>
                     </div>
                   </div>

--- a/src/components/AdPreview.tsx
+++ b/src/components/AdPreview.tsx
@@ -32,7 +32,7 @@ const adCopyTemplates = [
 ];
 
 export const AdPreview: React.FC<AdPreviewProps> = ({
-  initialImage = "https://images.pexels.com/photos/3555615/pexels-photo-3555615.jpeg",
+  initialImage = "https://images.pexels.com/photos/5997993/pexels-photo-5997993.jpeg",
   initialHeadline = "Beautiful Home in Prime Location",
   initialAdCopy = "Discover your dream home in this stunning property featuring modern amenities and a perfect location. Contact us today for a private showing!",
   onAdUpdate,

--- a/src/components/PackageSelection.tsx
+++ b/src/components/PackageSelection.tsx
@@ -21,7 +21,7 @@ export const PackageSelection: React.FC<PackageSelectionProps> = ({
   onOpenCongratulationsModal,
 }) => {
   const [selectedPlan, setSelectedPlan] = useState<"one-time" | "monthly">(
-    "one-time",
+    "monthly",
   );
   const [selectedPackage, setSelectedPackage] = useState<
     "starter" | "boost" | "growth" | "mastery"

--- a/src/components/PackageSelection.tsx
+++ b/src/components/PackageSelection.tsx
@@ -178,7 +178,7 @@ export const PackageSelection: React.FC<PackageSelectionProps> = ({
 
       {/* Ad Preview Section */}
       <AdPreview
-        initialImage="https://images.pexels.com/photos/3555615/pexels-photo-3555615.jpeg"
+        initialImage="https://images.pexels.com/photos/280229/pexels-photo-280229.jpeg"
         initialHeadline="Beautiful Home in Prime Location"
         initialAdCopy="Discover your dream home in this stunning property featuring modern amenities and a perfect location. Contact us today for a private showing!"
         onAdUpdate={(data) => {

--- a/src/components/PropertySetup.tsx
+++ b/src/components/PropertySetup.tsx
@@ -221,7 +221,7 @@ export const PropertySetup: React.FC<PropertySetupProps> = ({
                               .split("|")[0]
                               .trim()
                           : null) ||
-                        "https://images.pexels.com/photos/3555615/pexels-photo-3555615.jpeg"
+                        "https://images.pexels.com/photos/280229/pexels-photo-280229.jpeg"
                       }
                       className="w-full h-full object-cover"
                       alt="Property"


### PR DESCRIPTION
## Purpose
Based on user feedback, the default package selection has been changed from "one-time" to "monthly" to better align with user preferences and improve the initial user experience.

## Code changes
- **PackageSelection.tsx**: Updated the default `selectedPlan` state from "one-time" to "monthly"
- **AdPreview.tsx**: Updated display text from "Lofty Real Estate" to "Real Estate Service" and changed image recommendation text from "Recommended: 1200x630px" to "Recommended Aspect Ratio: 1:1 or 4:5"

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/6b96306cd5c047ecaa5199594a18cb81/nova-home)

👀 [Preview Link](https://6b96306cd5c047ecaa5199594a18cb81-nova-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6b96306cd5c047ecaa5199594a18cb81</projectId>-->
<!--<branchName>nova-home</branchName>-->